### PR TITLE
fix: update import suffix handling and improve build scripts

### DIFF
--- a/buf.gen.windows.yaml
+++ b/buf.gen.windows.yaml
@@ -15,4 +15,4 @@ plugins:
       - outputServices=nice-grpc
       - outputServices=generic-definitions
       - useExactTypes=false
-      - importSuffix=.js 
+      # omit .js suffix so tsc can resolve during declaration emit

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -15,4 +15,4 @@ plugins:
       - outputServices=nice-grpc
       - outputServices=generic-definitions
       - useExactTypes=false
-      - importSuffix=.js
+      # omit .js suffix so tsc can resolve during declaration emit

--- a/package.json
+++ b/package.json
@@ -25,11 +25,13 @@
   },
   "scripts": {
     "dev": "tsup --watch",
-    "build": "tsup",
+    "build": "(pnpm run gen:win || pnpm run gen) && tsup && tsc -p tsconfig.json",
     "clean": "rimraf dist",
-    "gen": "rimraf src/api/generated && make-dir src/api/generated && pnpm dlx @bufbuild/buf generate --template buf.gen.windows.yaml https://github.com/zitadel/zitadel.git --path ./proto/zitadel",
+    "gen": "rimraf src/api/generated && make-dir src/api/generated && pnpm dlx @bufbuild/buf generate --template buf.gen.yaml https://github.com/zitadel/zitadel.git --path ./proto/zitadel",
+    "gen:win": "rimraf src/api/generated && make-dir src/api/generated && pnpm dlx @bufbuild/buf generate --template buf.gen.windows.yaml https://github.com/zitadel/zitadel.git --path ./proto/zitadel",
+    "prepack": "(pnpm run gen:win || pnpm run gen) && tsup && tsc -p tsconfig.json",
     "test": "ava",
-    "pretest:ci": "tsup",
+    "pretest:ci": "pnpm run gen && tsup",
     "test:ci": "npm run test"
   },
   "keywords": [

--- a/src/api/clients.ts
+++ b/src/api/clients.ts
@@ -1,13 +1,13 @@
 import { ClientMiddleware, createChannel, createClientFactory } from 'nice-grpc';
-import { AdminServiceClient, AdminServiceDefinition } from './generated/zitadel/admin.js';
-import { AuthServiceClient, AuthServiceDefinition } from './generated/zitadel/auth.js';
-import { ManagementServiceClient, ManagementServiceDefinition } from './generated/zitadel/management.js';
-import { OIDCServiceClient, OIDCServiceDefinition } from './generated/zitadel/oidc/v2beta/oidc_service.js';
-import { OrganizationServiceClient, OrganizationServiceDefinition } from './generated/zitadel/org/v2beta/org_service.js';
-import { SessionServiceClient, SessionServiceDefinition } from './generated/zitadel/session/v2beta/session_service.js';
-import { SettingsServiceClient, SettingsServiceDefinition } from './generated/zitadel/settings/v2beta/settings_service.js';
-import { SystemServiceClient, SystemServiceDefinition } from './generated/zitadel/system.js';
-import { UserServiceClient, UserServiceDefinition } from './generated/zitadel/user/v2beta/user_service.js';
+import { AdminServiceClient, AdminServiceDefinition } from './generated/zitadel/admin';
+import { AuthServiceClient, AuthServiceDefinition } from './generated/zitadel/auth';
+import { ManagementServiceClient, ManagementServiceDefinition } from './generated/zitadel/management';
+import { OIDCServiceClient, OIDCServiceDefinition } from './generated/zitadel/oidc/v2beta/oidc_service';
+import { OrganizationServiceClient, OrganizationServiceDefinition } from './generated/zitadel/org/v2beta/org_service';
+import { SessionServiceClient, SessionServiceDefinition } from './generated/zitadel/session/v2beta/session_service';
+import { SettingsServiceClient, SettingsServiceDefinition } from './generated/zitadel/settings/v2beta/settings_service';
+import { SystemServiceClient, SystemServiceDefinition } from './generated/zitadel/system';
+import { UserServiceClient, UserServiceDefinition } from './generated/zitadel/user/v2beta/user_service';
 
 /**
  * Create a new gRPC service client for the Admin API of ZITADEL.

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,25 +1,17 @@
 import { defineConfig } from 'tsup';
 
 // CJS-only build for NestJS/Node environments; declarations generated separately
-export default defineConfig([
-  {
-    entry: ['src/**/*.ts'],
-    format: ['cjs'],
-    dts: false,
-    clean: true,
-    splitting: false,
-    sourcemap: true,
-    minify: false,
-    bundle: false,
-    target: 'node18',
-    platform: 'node',
-    outDir: 'dist/cjs',
-    outExtension: () => ({ js: '.js' }),
-  },
-  {
-    entry: ['src/**/*.ts'],
-    dts: { only: true },
-    clean: false,
-    outDir: 'dist/types',
-  },
-]);
+export default defineConfig({
+  entry: ['src/**/*.ts'],
+  format: ['cjs'],
+  dts: false,
+  clean: true,
+  splitting: false,
+  sourcemap: true,
+  minify: false,
+  bundle: false,
+  target: 'node18',
+  platform: 'node',
+  outDir: 'dist/cjs',
+  outExtension: () => ({ js: '.js' }),
+});


### PR DESCRIPTION
- Removed the `.js` suffix from import paths in configuration files to facilitate TypeScript declaration resolution.
- Updated `package.json` scripts to streamline the build process, including separate generation commands for Windows and general builds.
- Refactored `tsup` configuration for a cleaner structure.