### PR TITLE
chore: update Node.js version in workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
           
       - name: Install dependencies

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        version: [18, 20, 22]
+        os: [ubuntu-latest]
+        version: [22]
     name: test and build (node ${{ matrix.version }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     steps:
@@ -30,13 +30,7 @@ jobs:
           node-version: ${{ matrix.version }}
           cache: 'npm'
       - run: npm ci
-      
-            # Use Windows-compatible build on Windows, regular build elsewhere
-      - name: Build package (Windows)
-        if: matrix.os == 'windows-latest'
-        run: npm run build:windows
-      - name: Build package (Linux/Mac)
-        if: matrix.os != 'windows-latest'
+      - name: Build package
         run: npm run build
         
       - name: Build test files


### PR DESCRIPTION
- Changed Node.js version from 20 to 22 in the release workflow.
- Simplified testing workflow by limiting the OS matrix to only 'ubuntu-latest' and setting the Node.js version to 22.